### PR TITLE
changed the current-word style

### DIFF
--- a/web/src/app/details-feng/details-feng.component.scss
+++ b/web/src/app/details-feng/details-feng.component.scss
@@ -39,7 +39,10 @@
     }
 
     ul.examples-list {
-        margin-top: 0.5rem;
+        margin: 0.5rem 1rem 0 0.5rem;
+        padding-left: 0.5rem;
+        // background-color: #eff5f0;
+        color: #421f01;
     }
     
     li { 
@@ -63,8 +66,10 @@
     }
 
     .current-word {
-        font-weight: 900;
-        text-decoration: underline;
+        // font-weight: 900;
+        color: green;
+        // color: chocolate;
+        // text-decoration: underline;
     }
 
     .label {


### PR DESCRIPTION
我的思路来源是「新牛津英汉双解大词典」这个手机软件的界面。
![newoxford-screenshot](https://user-images.githubusercontent.com/26673556/83732478-1a5ec380-a61a-11ea-89fa-f1bec281309e.PNG)

修改的地方是：
1. 把例句的缩进调到与释义平齐；
2. 例句颜色与释义区别
3. 当前词用其他颜色区分

<img width="381" alt="demo-green" src="https://user-images.githubusercontent.com/26673556/83732277-cce25680-a619-11ea-8109-f40dc5f333f0.png">

有考虑过用亮一些的褐色来突出，整体看起来似乎更协调一些，但是担心对比度不太够，还是挑了绿色。
<img width="381" alt="demo-chocolate" src="https://user-images.githubusercontent.com/26673556/83732284-d075dd80-a619-11ea-8ca9-c8e1ec6790e4.png">
