### PR TITLE
disable renovate for envoyproxy/envoy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "automerge": true
     },
     {
-      "packageNames": ["@bazel/ibazel"],
+      "packageNames": ["@bazel/ibazel", "envoyproxy/envoy"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Because our envoy configuration file is not compatible with newer versions of envoy