### PR TITLE
Fix hanging pipeline

### DIFF
--- a/.azure/pipelines/docker-images.yml
+++ b/.azure/pipelines/docker-images.yml
@@ -79,14 +79,14 @@ steps:
   displayName: 'Bazel build //web/src/...'
 
 - script: |
-    bazel build --config=release //server/opencc_daemon:image //server/gateway:gateway_image //assets:tts_audio_wav_image &&
+    bazel build --config=release //server/opencc_daemon:image //server/gateway:image //assets:tts_audio_wav_image &&
     bazel run --config=release //server/opencc_daemon:image &&
-    bazel run --config=release //server/gateway:gateway_image &&
+    bazel run --config=release //server/gateway:image &&
     bazel run --config=release //assets:tts_audio_wav_image &&
     docker tag bazel/server/opencc_daemon:image ztl8702/opencc-daemon:ci-$(Build.BuildNumber) &&
     docker tag bazel/server/opencc_daemon:image registry.cn-hangzhou.aliyuncs.com/zingzeu/opencc-daemon:ci-$(Build.BuildNumber) &&
-    docker tag bazel/server/gateway:gateway_image ztl8702/yngdieng-grpc-gateway:ci-$(Build.BuildNumber) &&
-    docker tag bazel/server/gateway:gateway_image registry.cn-hangzhou.aliyuncs.com/zingzeu/yngdieng-grpc-gateway:ci-$(Build.BuildNumber)
+    docker tag bazel/server/gateway:image ztl8702/yngdieng-grpc-gateway:ci-$(Build.BuildNumber) &&
+    docker tag bazel/server/gateway:image registry.cn-hangzhou.aliyuncs.com/zingzeu/yngdieng-grpc-gateway:ci-$(Build.BuildNumber)
   displayName: 'Bazel build: OpenCC Daemon image, grpc-gateway, TTS Audio image'
 
 - script: |

--- a/server/gateway/BUILD
+++ b/server/gateway/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
 
 go_library(
     name = "server_lib",
@@ -22,4 +23,9 @@ go_image(
     name = "gateway_image",
     embed = [":server_lib"],
     visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "image",
+    base = ":gateway_image",
 )


### PR DESCRIPTION
bazel run a go_image rule actually executes the image; what we need to run in the docker-images.yml pipeline is ﻿a container_image rule, which registers the image with the local Docker daemon
