### PR TITLE
《关于榕典》页面更新

### DIFF
--- a/web/src/app/about/about.component.html
+++ b/web/src/app/about/about.component.html
@@ -2,6 +2,24 @@
   <h1>关于榕典</h1>
   <p>榕典是一款多来源的福州话（闽东方言）线上辞典。榕典的使命是：让平话知识触手可及。</p>
 
+  <h2>文献来源</h2>
+  <ul>
+    <li>已上线（或部分上线）
+      <ul>
+        <li>冯爱珍 1998 《福州方言词典》，江苏教育出版社。</li>
+        <li>李如龙 王升魁校注 2001 《戚林八音校注》，福建人民出版社。</li>
+        <li>R. S. Maclay & C. C. Baldwin & S. H. Leger, 1929, <em>Dictionary of the Foochow Dialect</em>, Presbyterian Mission Press of Shanghai.<br>
+        （注：<em>Dictionary of the Foochow Dialect</em><span class="space">&nbsp;</span>一书无官方译名，故而中文译名多样，榕典取其中一种，乃《榕腔注音辞典》。该书的数位化仅完成了《目录（Index of Character）》部分。)</li>
+      </ul></li>
+    <li>未上线（校对中）
+      <ul>
+        <li>钟德明 1906 《加订美全八音》，永昌书局。</li>
+        <li>李如龙 梁玉璋 邹光 陈泽平 1994 《福州方言词典》，福建人民出版社。</li>
+        <li>福建连江县地方志编纂委员会 2000 《连江县志·方言志》，方志出版社。</li>
+      </ul></li>
+  </ul>
+
+
   <h2>联系我们</h2>
   <ul>
     <li>邮箱：<a mat-button color="primary" href="mailto:contact@zingzeu.org">📮&ensp;contact@zingzeu.org&ensp;</a>
@@ -29,6 +47,7 @@
     <li>感谢福州厝边公司的协助。</li>
     <li>感谢上海师范大学王弘治师生数字化《美全八音》的努力。</li>
     <li>感谢所有参与文本数位化工作的志愿者。（贡献者名单统计中）</li>
+    <li>感谢福建省美术家协会的朱伟平老师为榕典题写<span class="space">&nbsp;</span>logo。</li> 
   </ul>
 
   <p>真鸟囝团队出品</p>

--- a/web/src/app/help/help.component.html
+++ b/web/src/app/help/help.component.html
@@ -50,10 +50,10 @@
       <ol>
         <li>若使用优先级较高的用字会产生歧义，则不选择该写法。</li>
         <li>在本字与俗字中，优先选择学界有共识的、没有争议的本字与被民间普遍接受的俗字。若二者冲突，则以民间接受度为基准。</li>
-        <li>若只有同级比较，那么以<span class="space">&ensp;</span>Unicode<span class="space">&ensp;</span>码拓展集的先后顺序为优先。
+        <li>若只有同级比较，那么以<span class="space">&nbsp;</span>Unicode<span class="space">&nbsp;</span>码拓展集的先后顺序为优先。
           <ol>
-            <li>若某来源的写法没有<span class="space">&ensp;</span>Unicode<span class="space">&ensp;</span>码，则优先级置于最低。</li>
-            <li>若<span class="space">&ensp;</span>Unicode<span class="space">&ensp;</span>码先后顺序一致，则按民间接受度为基准。</li>
+            <li>若某来源的写法没有<span class="space">&nbsp;</span>Unicode<span class="space">&nbsp;</span>码，则优先级置于最低。</li>
+            <li>若<span class="space">&nbsp;</span>Unicode<span class="space">&nbsp;</span>码先后顺序一致，则按民间接受度为基准。</li>
           </ol>
         </li>
       </ol>
@@ -74,9 +74,9 @@
 
   <h3>谐音前缀、分音词</h3>
   <ol>
-    <li>将“㞢”置于词根前表示主元音为<span class="space">&ensp;</span>i<span class="space">&ensp;</span>的谐音前缀，如“㞢写”（音<span class="space">&ensp;</span>si<sup>53</sup> sia<sup>33</sup>，单字音<span class="space">&ensp;</span>sia<sup>33</sup>）。此写法来源于江苏教育出版社的《福州方言词典》，原书选用“之”字，为避免产生歧义，使用“之”的异体“㞢”。</li>
-    <li>将“噜”、“㖮”置于词根前，分别表示发音为<span class="space">&ensp;</span>lu、lung<span class="space">&ensp;</span>的谐音前缀，如“㞢噜傲”（音<span class="space">&ensp;</span>ngi<sup>21</sup> lu<sup>53</sup> ngoo<sup>213</sup>，单字音<span class="space">&ensp;</span>ngoo<sup>213</sup>）。</li>
-    <li>将“々”置于词根后表示分音词，如“反々”（音<span class="space">&ensp;</span>be<sup>33</sup> leing<sup>33</sup>，单字音<span class="space">&ensp;</span>being<sup>33</sup>）。此写法来源于陈泽平老师的《福州方言研究》。</li>
+    <li>将“㞢”置于词根前表示主元音为<span class="space">&nbsp;</span>i<span class="space">&nbsp;</span>的谐音前缀，如“㞢写”（音<span class="space">&nbsp;</span>si<sup>53</sup> sia<sup>33</sup>，单字音<span class="space">&nbsp;</span>sia<sup>33</sup>）。此写法来源于江苏教育出版社的《福州方言词典》，原书选用“之”字，为避免产生歧义，使用“之”的异体“㞢”。</li>
+    <li>将“噜”、“㖮”置于词根前，分别表示发音为<span class="space">&nbsp;</span>lu、lung<span class="space">&nbsp;</span>的谐音前缀，如“㞢噜傲”（音<span class="space">&nbsp;</span>ngi<sup>21</sup> lu<sup>53</sup> ngoo<sup>213</sup>，单字音<span class="space">&nbsp;</span>ngoo<sup>213</sup>）。</li>
+    <li>将“々”置于词根后表示分音词，如“反々”（音<span class="space">&nbsp;</span>be<sup>33</sup> leing<sup>33</sup>，单字音<span class="space">&nbsp;</span>being<sup>33</sup>）。此写法来源于陈泽平老师的《福州方言研究》。</li>
   </ol>
 
   <h3>推荐用字</h3>

--- a/web/src/app/help/help.component.scss
+++ b/web/src/app/help/help.component.scss
@@ -30,13 +30,6 @@ ol > li {
   padding-left: 10px;
 }
 
-span.space,
-span.space[hidden] {
-  display: inline;
-  visibility: hidden;
-  font: 0.89em Arial;
-}
-
 .mat-button {
   padding-left: 0;
   padding-right: 0;

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -174,3 +174,12 @@ body {
 }
 
 // END word details
+
+// trivial hack for the spacing
+// between hanzi and alphabetical letters
+span.space {
+  white-space: pre-wrap;
+  display: inline;
+  visibility: hidden;
+  font: 0.89em Arial;
+}


### PR DESCRIPTION
按照子善在榕典工作组微信群提供的文本内容更新了《关于榕典》页面。英文书名我自作主张加上了斜体。

另：`span.space`这个元素想达到的效果是在中西文之间加上间隙但不添加原文之外空格，之前其实一直没有实现，刚刚又试了一下似乎能达成了，就移到全局样式表里了。